### PR TITLE
run dependabot one day a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "19:00"
-      timezone: "Europe/Vienna"
+      interval: "cron"
+      cronjob: "0 0,2,4,6 * * 2"
     open-pull-requests-limit: 1
     cooldown:
       semver-patch-days: 5
@@ -25,10 +24,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
-      time: "20:00"
-      timezone: "Europe/Vienna"
+      interval: "cron"
+      cronjob: "0 0,2,4,6 * * 2"
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7


### PR DESCRIPTION
The old setup checked for updates every day and auto-merged them the
same day. That didn't work well for for fast-moving dependencies because
the same package could be bumped on consecutive days as new eligible
releases kept appearing.

This moves the repo to a weekly batch window instead. Dependabot now
runs four times on the day assigned for this repo, spaced two hours
apart, and [mrj](https://github.com/dhth/mrj) is expected to run in the
interleaved hours. That keeps follow-up updates inside the same
maintenance window, frees the open PR slot between runs, and reduces the
day-to-day drip of small dependency PRs.
